### PR TITLE
use -autoservername for socket to meet SNI requirement

### DIFF
--- a/packages/http.tcl
+++ b/packages/http.tcl
@@ -16,7 +16,7 @@ proc ::nfs::Http::getRequest {uri {body { }}} {
 	set url "https://api.nearlyfreespeech.net$uri"
 	set header [createHeader $uri $body]
 
-	http::register https 443 [list ::tls::socket -tls1 1]
+	http::register https 443 [list ::tls::socket -tls1 1 -autoservername 1]
 
 	try {set token [http::geturl $url -headers $header -query $body]}
 	


### PR DESCRIPTION
I found that my dynamic DNS hadn't updated for a while, apparently because this script's API requests had been failing  with this 403 error:
> You don't have permission to access this resource.Reason: The client software did not provide a hostname using Server Name Indication (SNI), which is required to access this server.

Adding `-autoservername 1` to the socket seems to fix this. I'm not a Tcl programmer and I'm not that familiar with networking stuff, so I'm really not sure this is the right thing to do, but hopefully it's useful!