### PR TITLE
Configurable cron schedule for Docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM alpine:latest
 
-# docker run --rm -it -v /home/ace/Scripts/nfs-dynamic-dns:/root 
-
 COPY *.tcl /root/
 COPY packages/* /root/packages/
 COPY LICENSE /root/LICENSE
@@ -20,6 +18,10 @@ RUN curl -sSL https://github.com/tcltk/tcllib/archive/release.tar.gz | tar -xz -
 	rm -rf /tmp/tcllib*
 
 RUN mkdir /logs
+
 WORKDIR /root
-RUN echo "$(crontab -l 2>&1; echo "*/60     *       *       *       *       /root/dns.tcl")" | crontab -
+
+ARG CRON_SCHEDULE="*/30 * * * *"
+RUN echo "$(crontab -l 2>&1; echo "${CRON_SCHEDULE} /root/dns.tcl")" | crontab -
+
 CMD ["crond", "-f", "2>&1"]

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ When using the Docker file, it's by default scheduled to run every 30 minutes. H
 container. The `CRON_SCHEDULE` [build arg](https://docs.docker.com/engine/reference/builder/#arg) can be overriden.
 
 With docker, the build step (step 2) can be done like this:
+
 `$ docker build --build-arg CRON_SCHEDULE="*/5 * * * *" -t nfs-dynamic-dns .`
 
 With docker compose, it can be done like this:

--- a/README.md
+++ b/README.md
@@ -71,8 +71,30 @@ to run the container locally and be put into a shell where you can run `./dns.tc
 If your setup uses environment variables, you will also need to add the `--env-file` argument (or specify variables individually with [the `-e` docker flag](https://docs.docker.com/engine/reference/run/#env-environment-variables)). The `--env-file` option is for [docker run](https://docs.docker.com/engine/reference/commandline/run/) and the env file format can be found [here](https://docs.docker.com/compose/env-file/).
 
 ## Scheduling
-It can even be setup to run as a cron job to completely automate this process. Something such as:
+It can be setup to run as a cron job to completely automate this process. Something such as:
 > @hourly /usr/local/bin/tclsh /scripts/nfs-dynamic-dns/dns.tcl
+
+### Docker
+When using the Docker file, it's by default scheduled to run every 30 minutes. However, this is configurable when building the
+container. The `CRON_SCHEDULE` [build arg](https://docs.docker.com/engine/reference/builder/#arg) can be overriden.
+
+With docker, the build step (step 2) can be done like this:
+`$ docker build --build-arg CRON_SCHEDULE="*/5 * * * *" -t nfs-dynamic-dns .`
+
+With docker compose, it can be done like this:
+```yaml
+version: "3"
+
+services:
+  nfs-dynamic-dns:
+    image: nfs-dynamic-dns
+    build:
+      context: ./nfs-dynamic-dns
+      args:
+        - CRON_SCHEDULE=*/5 * * * *
+    container_name: nfs-dynamic-dns
+...
+ ```
 
 ## Troubleshooting
 The script communicates with NearlyFreeSpeech.NET via its RESTful API. Specifics about the API can be found [here](https://members.nearlyfreespeech.net/wiki/API/Introduction).


### PR DESCRIPTION
Use Dockerfile ARG to allow overriding the cron schedule when building the container. I also reduced the default schedule down to 30 minutes. Resolves #10 

FYI @MoralCode 