### PR TITLE
Use replaceRR API and don't swallow API errors

### DIFF
--- a/dns.tcl
+++ b/dns.tcl
@@ -36,25 +36,19 @@ proc updateIPs {current_ip domain_ip} {
 		puts "[clock format $now -format {%y-%m-%d %H:%M:%S}]: The domain IP doesn't appear to be set yet."
 	} else {
 		puts "[clock format $now -format {%y-%m-%d %H:%M:%S}]: Current IP: $current_ip doesn't match Domain IP: $domain_ip"
-
-		# The case where the server returns 0.0.0.0 is probably
-		# vestigial, but I'm leaving it in just in case.
-		if {$domain_ip ne {0.0.0.0}} {
-			::nfs::Http::removeDomain $domain_ip
-		}
 	}
 
-	::nfs::Http::addDomain $current_ip
+	# Set or update the domain IP
+	::nfs::Http::replaceDomain $current_ip
 
+	# Check to see if the update was successful
+	set now [clock seconds]
 	if {[::nfs::Utility::doIPsMatch]} {
 		set domain_ip [::nfs::Http::fetchDomainIP]
-		set now [clock seconds]
 
 		puts "[clock format $now -format {%y-%m-%d %H:%M:%S}]: IPs match now! Current IP: $current_ip Domain IP: $domain_ip"
-		exit
 	} else {
 		puts "[clock format $now -format {%y-%m-%d %H:%M:%S}]: They still don't match. Current IP: $current_ip Domain IP: $domain_ip"
-		exit
 	}
 }
 

--- a/packages/utility.tcl
+++ b/packages/utility.tcl
@@ -28,8 +28,10 @@ proc ::nfs::Utility::doIPsMatch {} {
 
 proc ::nfs::Utility::validateResponse {resp} {
   if {[dict exists $resp error]} {
-    puts "ERROR: [dict get $resp error]"
-    puts "ERROR: [dict get $resp debug]"
+    set now [clock seconds]
+
+    puts "[clock format $now -format {%y-%m-%d %H:%M:%S}]: ERROR: [dict get $resp error]"
+    puts "[clock format $now -format {%y-%m-%d %H:%M:%S}]: ERROR: [dict get $resp debug]"
 
     exit
   }


### PR DESCRIPTION
Instead of removing the domain and replacing it as 2 steps when the IPs don't match, use the `replaceRR` API instead. Before if the `removeRR` succeeded but the `addRR` failed (such as trying to set an invalid IP), the domain would have been removed completely which is probably not what we want.

The script also now logs errors if the `replaceRR` call failed so it should be more obvious what the issue could be.

Resolves #13 