### PR TITLE
Add Docker image push job to workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,54 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  push-image:
+    name: Push image
+    # We don't push images on pull requests
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read #  to fetch code (actions/checkout)
+      packages: write #  to push docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        id: setup-buildx
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set container metadata
+        uses: docker/metadata-action@v5
+        id: meta
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: index,manifest
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/nfs-dynamic-dns
+          # Pushes to the main branch update the *:devel-latest tag
+          # Releases update the *:latest tag and the *:<version> tag
+          tags: |
+            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
+      - name: Build and push
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          # Only push if we've tagged the image in the metadata step
+          push: ${{ steps.meta.outputs.tags != '' }}
+          tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This PR adds a github action that builds and pushes the docker image to the Github Container Registry, making it appear under the "packages" section of the sidebar.

The usecase for me is that it allows me to more easily update to the latest version with simply a docker pull, rather than building myself and/or uploading a `docker save` tarball