### PR TITLE
Let's Encrypt certificate issuing using domain-based ACME challenge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.claude/
 .env*
 .venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.8-alpine
 # Install dependencies
 RUN pip install --upgrade pip
 RUN pip3 install requests python-dotenv
-RUN apk add --no-cache curl socat bash
+RUN apk add --no-cache curl socat bash openssl
 
 # Copy scripts and docs
 COPY *.py /root/
@@ -14,14 +14,14 @@ COPY README.md /root/README.md
 RUN chmod +x /root/entrypoint.sh
 
 # Install acme.sh
-RUN curl https://get.acme.sh | sh
+RUN curl -sSL https://get.acme.sh | sh
 
 # Install NFSN DNS plugin for acme.sh
 COPY dns_nfsn.sh /root/.acme.sh/dnsapi/dns_nfsn.sh
 RUN chmod +x /root/.acme.sh/dnsapi/dns_nfsn.sh
 
 # Directories for logs and certs
-RUN mkdir -p /logs /certs
+RUN mkdir -p /logs /certs && chmod 777 /logs
 
 WORKDIR /root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,37 @@
 FROM python:3.8-alpine
-# FROM alpine
 
+# Install dependencies
 RUN pip install --upgrade pip
-
 RUN pip3 install requests python-dotenv
+RUN apk add --no-cache curl socat bash
 
+# Copy scripts and docs
 COPY *.py /root/
+COPY entrypoint.sh /root/entrypoint.sh
 COPY LICENSE /root/LICENSE
 COPY README.md /root/README.md
 
-# RUN echo '@community http://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories && \
-# 	echo '@edge http://dl-cdn.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories && \
-# 	apk add --upgrade --no-cache --update ca-certificates wget git curl openssh tar gzip python3 apk-tools@edge && \
-# 	apk upgrade --update --no-cache
+RUN chmod +x /root/entrypoint.sh
 
-RUN mkdir /logs
+# Install acme.sh
+RUN curl https://get.acme.sh | sh
+
+# Install NFSN DNS plugin for acme.sh
+COPY dns_nfsn.sh /root/.acme.sh/dnsapi/dns_nfsn.sh
+RUN chmod +x /root/.acme.sh/dnsapi/dns_nfsn.sh
+
+# Directories for logs and certs
+RUN mkdir -p /logs /certs
 
 WORKDIR /root
 
+# Set cron schedules (with backwards compatibility)
 ARG CRON_SCHEDULE="*/30 * * * *"
-RUN echo "$(crontab -l 2>&1; echo "${CRON_SCHEDULE} python3 /root/nfsn-ddns.py")" | crontab -
+ARG DDNS_CRON="${CRON_SCHEDULE}"
+ARG CERT_CRON="0 3 * * *"
 
-CMD ["crond", "-f", "2>&1"]
+# Convert to ENV for runtime use in entrypoint.sh
+ENV DDNS_CRON="${DDNS_CRON}"
+ENV CERT_CRON="${CERT_CRON}"
+
+ENTRYPOINT ["/root/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Configurations are set by providing the script with environment variables or com
 | API_KEY | | Y | API key for using NFSN's APIs. This can be obtained via the Member Interface > "Profile" tab > "Actions" > "Manage API Key" |
 | DOMAIN | | Y | Domain that the subdomain belongs to |
 | SUBDOMAIN | | N | Subdomain to update with the script. Leave blank for the bare domain name |
+| ENABLE_DDNS | | N | Enable dynamic DNS updates. Defaults to `true` for backwards compatibility. Set to `false` to disable DDNS and run only certificate management. |
+| ENABLE_CERTS | | N | Enable Let's Encrypt certificate issuing and renewal via ACME DNS-01 challenge. Defaults to `false`. Set to `true` to enable certificate management. |
+| DDNS_CRON | | N | Cron schedule for DDNS updates. Defaults to `*/30 * * * *` (every 30 minutes). Only used if `ENABLE_DDNS=true`. Can also be set at build time via `--build-arg`. |
+| CERT_CRON | | N | Cron schedule for certificate renewal checks. Defaults to `0 3 * * *` (daily at 3 AM). Only used if `ENABLE_CERTS=true`. Can also be set at build time via `--build-arg`. |
 | IP_PROVIDER | | N | Use a different IP providing service than the default: [http://ipinfo.io/ip](http://ipinfo.io/ip) This might be useful if the default provider is unavailable or is blocked. The alternate provider MUST be served over `http` (please open an issue if this is ever a problem) and MUST return ONLY the IP in the response body |
 | IPV6_PROVIDER | | N | Use a different IP providing service than the default: [http://v6.ipinfo.io/ip](http://v6.ipinfo.io/ip) This might be useful if the default provider is unavailable or is blocked. The alternate provider MUST be served over `http` (please open an issue if this is ever a problem) and MUST return ONLY the IP in the response body |
 | ENABLE_IPV6 | `--ipv6` or `-6` | N | Set this to any value to also cause the script to check for and update AAAA records on the specified domain. |
@@ -46,10 +50,26 @@ $ export USERNAME=username API_KEY=api_key DOMAIN=domain.com SUBDOMAIN=subdomain
 or you can put your variables in a `.env` file:
 
 ```
-API_KEY=
-USERNAME=
-DOMAIN=
-SUBDOMAIN=
+# NFSN credentials
+USERNAME=your_username
+API_KEY=your_api_key
+DOMAIN=example.com
+SUBDOMAIN=subdomain
+
+# Feature flags
+ENABLE_DDNS=true        # Enable dynamic DNS (default: true)
+ENABLE_CERTS=false      # Enable Let's Encrypt certs (default: false)
+
+# Optional: Customize schedules
+#DDNS_CRON=*/30 * * * *  # Every 30 minutes (default)
+#CERT_CRON=0 3 * * *     # Daily at 3 AM (default)
+
+# Optional: IPv6 support
+#ENABLE_IPV6=true
+
+# Optional: Customize IP providers
+#IP_PROVIDER=http://ipinfo.io/ip
+#IPV6_PROVIDER=http://v6.ipinfo.io/ip
 ```
 
 ### With Docker
@@ -85,14 +105,23 @@ to run the container locally and be put into a shell where you can run `python3 
 If your setup uses environment variables, you will also need to add the `--env-file` argument (or specify variables individually with [the `-e` docker flag](https://docs.docker.com/engine/reference/run/#env-environment-variables)). The `--env-file` option is for [docker run](https://docs.docker.com/engine/reference/commandline/run/) and the env file format can be found [here](https://docs.docker.com/compose/env-file/).
 
 ### Docker
-When using the Docker file, it's by default scheduled to run every 30 minutes. However, this is configurable when building the
-container. The `CRON_SCHEDULE` [build arg](https://docs.docker.com/engine/reference/builder/#arg) can be overriden.
+When using the Docker file, DDNS updates are scheduled to run every 30 minutes by default. This is configurable when building the
+container using [build args](https://docs.docker.com/engine/reference/builder/#arg).
 
-With docker, the build step (step 2) can be done like this:
+#### Customizing Cron Schedules
 
-`$ docker build --build-arg CRON_SCHEDULE="*/5 * * * *" -t nfs-dynamic-dns .`
+You can customize the schedules using build args:
 
-With docker compose, it can be done like this:
+**With docker:**
+```bash
+# For DDNS updates (backwards compatible)
+$ docker build --build-arg CRON_SCHEDULE="*/5 * * * *" -t nfs-dynamic-dns .
+
+# Or use the new arg names
+$ docker build --build-arg DDNS_CRON="*/5 * * * *" --build-arg CERT_CRON="0 2 * * *" -t nfs-dynamic-dns .
+```
+
+**With docker compose:**
 ```yaml
 services:
   nfs-dynamic-dns:
@@ -100,10 +129,106 @@ services:
     build:
       context: ./nfs-dynamic-dns
       args:
-        - CRON_SCHEDULE=*/5 * * * *
+        - DDNS_CRON=*/5 * * * *
+        - CERT_CRON=0 2 * * *
     container_name: nfs-dynamic-dns
 ...
  ```
+
+**Note:** The `CRON_SCHEDULE` build arg is still supported for backwards compatibility and maps to `DDNS_CRON`.
+
+## ACME Certificate Management
+
+This application can automatically issue and renew Let's Encrypt certificates using DNS-01 challenges via the NFSN DNS API.
+
+### Requirements for Certificate Management
+- Set `ENABLE_CERTS=true` environment variable
+- Ensure `DOMAIN` environment variable is set (certificates will be issued for `$DOMAIN` and `*.$DOMAIN`)
+- Mount a volume to `/certs` to persist certificates outside the container
+
+### Certificate Paths
+Certificates are stored in `/certs`:
+- Certificate: `/certs/$DOMAIN.crt`
+- Private key: `/certs/$DOMAIN.key`
+
+### Docker Example with Certificates
+```bash
+docker run -d \
+  --name nfsn-dynamic-dns \
+  --env-file .env \
+  -v /path/to/certs:/certs \
+  nfs-dynamic-dns
+```
+
+Make sure your `.env` file includes:
+```
+ENABLE_CERTS=true
+```
+
+### Docker Compose Example with Certificates
+```yaml
+version: "3"
+
+services:
+  nfs-dynamic-dns:
+    image: nfs-dynamic-dns
+    build: ./nfs-dynamic-dns
+    container_name: nfs-dynamic-dns
+    network_mode: host
+    environment:
+      - USERNAME=username
+      - API_KEY=api_key
+      - DOMAIN=domain.com
+      - SUBDOMAIN=subdomain
+      - ENABLE_DDNS=true
+      - ENABLE_CERTS=true
+    volumes:
+      - ./certs:/certs
+      - ./logs:/logs
+    restart: unless-stopped
+```
+
+### Running Only Certificate Management (No DDNS)
+To run only certificate issuing/renewal without DDNS:
+```bash
+docker run -d \
+  --name nfsn-certs \
+  -e USERNAME=username \
+  -e API_KEY=api_key \
+  -e DOMAIN=domain.com \
+  -e ENABLE_DDNS=false \
+  -e ENABLE_CERTS=true \
+  -v /path/to/certs:/certs \
+  nfs-dynamic-dns
+```
+
+### Manual Certificate Operations
+To manually issue a certificate inside the container:
+```bash
+docker exec nfsn-dynamic-dns /root/.acme.sh/acme.sh --issue \
+  -d domain.com -d "*.domain.com" \
+  --dns dns_nfsn \
+  --cert-file /certs/domain.com.crt \
+  --key-file /certs/domain.com.key \
+  --home /root/.acme.sh
+```
+
+To force renewal:
+```bash
+docker exec nfsn-dynamic-dns /root/.acme.sh/acme.sh --renew \
+  -d domain.com \
+  --force \
+  --home /root/.acme.sh
+```
+
+### Customizing Certificate Renewal Schedule
+Both DDNS and certificate renewal schedules can be customized via environment variables:
+
+```yaml
+environment:
+  - DDNS_CRON=*/15 * * * *      # Check DDNS every 15 minutes
+  - CERT_CRON=0 2 * * *         # Check renewal daily at 2 AM
+```
 
 ## Troubleshooting
 The script communicates with NearlyFreeSpeech.NET via its RESTful API. Specifics about the API can be found [here](https://members.nearlyfreespeech.net/wiki/API/Introduction).

--- a/dns_nfsn.sh
+++ b/dns_nfsn.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# NFSN DNS API plugin for acme.sh
+# Requires: USERNAME, API_KEY, DOMAIN environment variables
+
+dns_nfsn_add() {
+  fulldomain=$1
+  txtvalue=$2
+
+  # Extract subdomain from fulldomain
+  # For _acme-challenge.example.com, we want _acme-challenge
+  # For _acme-challenge.*.example.com, we want _acme-challenge.*
+  subdomain="${fulldomain%.$DOMAIN}"
+
+  echo "[ACME] Adding DNS record: $subdomain = $txtvalue"
+  python3 /root/nfsn-acme.py auth "$txtvalue" "$subdomain"
+
+  # Wait for DNS propagation
+  sleep 30
+
+  return 0
+}
+
+dns_nfsn_rm() {
+  fulldomain=$1
+  txtvalue=$2
+
+  # Extract subdomain from fulldomain
+  subdomain="${fulldomain%.$DOMAIN}"
+
+  echo "[ACME] Removing DNS record: $subdomain"
+  python3 /root/nfsn-acme.py cleanup "$subdomain"
+
+  return 0
+}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -e
+
+# Load environment variables from .env
+if [ -f /root/.env ]; then
+  export $(grep -v '^#' /root/.env | xargs)
+fi
+
+# Set defaults (backwards compatibility)
+ENABLE_DDNS="${ENABLE_DDNS:-true}"
+ENABLE_CERTS="${ENABLE_CERTS:-false}"
+DDNS_CRON="${DDNS_CRON:-*/30 * * * *}"
+CERT_CRON="${CERT_CRON:-0 3 * * *}"
+
+CERT_HOME="/root/.acme.sh"
+CERT_PATH="/certs"
+
+# Clear existing crontab
+crontab -r 2>/dev/null || true
+
+# Conditional DDNS cron setup
+if [ "$ENABLE_DDNS" = "true" ]; then
+  echo "[INIT] Setting up DDNS cron: $DDNS_CRON"
+  (crontab -l 2>/dev/null; echo "$DDNS_CRON python3 /root/nfsn-ddns.py >> /logs/ddns.log 2>&1") | crontab -
+else
+  echo "[INIT] DDNS disabled"
+fi
+
+# Conditional ACME setup
+if [ "$ENABLE_CERTS" = "true" ]; then
+  echo "[INIT] Certificate management enabled"
+  mkdir -p "$CERT_PATH"
+
+  # Issue initial certificate if needed
+  DOMAIN_CERT_FILE="$CERT_PATH/$DOMAIN.crt"
+  DOMAIN_KEY_FILE="$CERT_PATH/$DOMAIN.key"
+
+  if [ ! -f "$DOMAIN_CERT_FILE" ] || [ ! -f "$DOMAIN_KEY_FILE" ]; then
+    echo "[INIT] Issuing certificate for $DOMAIN"
+    $CERT_HOME/acme.sh --issue \
+      -d "$DOMAIN" -d "*.$DOMAIN" \
+      --dns dns_nfsn \
+      --cert-file "$DOMAIN_CERT_FILE" \
+      --key-file "$DOMAIN_KEY_FILE" \
+      --home "$CERT_HOME" || echo "[ERROR] Cert issuing failed, will retry via cron"
+  else
+    echo "[INIT] Certificate exists for $DOMAIN"
+  fi
+
+  # Add renewal cron
+  echo "[INIT] Setting up ACME renewal cron: $CERT_CRON"
+  (crontab -l 2>/dev/null; echo "$CERT_CRON $CERT_HOME/acme.sh --renew --home $CERT_HOME --cron >> /logs/acme.log 2>&1") | crontab -
+else
+  echo "[INIT] Certificate management disabled"
+fi
+
+# Show final crontab for debugging
+echo "[INIT] Final crontab:"
+crontab -l || echo "  (empty)"
+
+# Start cron in foreground
+exec crond -f -d 8

--- a/nfsn-acme.py
+++ b/nfsn-acme.py
@@ -1,0 +1,41 @@
+import os
+import sys
+
+from nfsn_api import fetchDNSRecordData, addDNSRecord, removeDNSRecord
+
+def fetchDomainValue(name, domain, nfsn_username, nfsn_apikey):
+    return fetchDNSRecordData(name, domain, "TXT", nfsn_username, nfsn_apikey)
+
+def createTxtRecord(name, value, domain, nfsn_username, nfsn_apikey):
+    addDNSRecord(domain, name, "TXT", value, 300, nfsn_username, nfsn_apikey)
+    print(f"[ACME] Created TXT record {name}={value}")
+
+def deleteTxtRecord(name, domain, nfsn_username, nfsn_apikey):
+    value = fetchDomainValue(name, domain, nfsn_username, nfsn_apikey)
+
+    if value is None:
+        print(f"[ACME] No TXT record found for {name}, skipping deletion")
+        return
+
+    removeDNSRecord(domain, name, "TXT", value, nfsn_username, nfsn_apikey)
+    print(f"[ACME] Deleted TXT record {name}")
+
+if __name__ == "__main__":
+    nfsn_username = os.getenv('USERNAME')
+    nfsn_apikey = os.getenv('API_KEY')
+    nfsn_domain = os.getenv('DOMAIN')
+
+    if not nfsn_username or not nfsn_apikey or not nfsn_domain:
+      print("Missing required environment variables (NFSN_USER, NFSN_API_KEY, DOMAIN)")
+      sys.exit(1)
+
+    if len(sys.argv) < 2:
+        sys.exit(0)
+    command = sys.argv[1]
+    if command == "auth":
+        token = sys.argv[2]
+        domain = sys.argv[3]
+        createTxtRecord(f"_acme-challenge.{domain}", token, nfsn_domain, nfsn_username, nfsn_apikey)
+    elif command == "cleanup":
+        domain = sys.argv[2]
+        deleteTxtRecord(f"_acme-challenge.{domain}", nfsn_domain, nfsn_username, nfsn_apikey)

--- a/nfsn-acme.py
+++ b/nfsn-acme.py
@@ -34,8 +34,8 @@ if __name__ == "__main__":
     command = sys.argv[1]
     if command == "auth":
         token = sys.argv[2]
-        domain = sys.argv[3]
-        createTxtRecord(f"_acme-challenge.{domain}", token, nfsn_domain, nfsn_username, nfsn_apikey)
+        subdomain = sys.argv[3]
+        createTxtRecord(subdomain, token, nfsn_domain, nfsn_username, nfsn_apikey)
     elif command == "cleanup":
-        domain = sys.argv[2]
-        deleteTxtRecord(f"_acme-challenge.{domain}", nfsn_domain, nfsn_username, nfsn_apikey)
+        subdomain = sys.argv[2]
+        deleteTxtRecord(subdomain, nfsn_domain, nfsn_username, nfsn_apikey)

--- a/nfsn-ddns.py
+++ b/nfsn-ddns.py
@@ -1,79 +1,19 @@
 import argparse
-import hashlib
-import random
-import string
 import os
-from datetime import datetime, timezone
-from ipaddress import IPv4Address, IPv6Address, ip_address
-from typing import Union, NewType, Dict
-from urllib.parse import urlencode
-from pathlib import Path
-
 import requests
-from dotenv import load_dotenv
+from ipaddress import IPv4Address, IPv6Address, ip_address
+from pathlib import Path
+from typing import Union, NewType
+
+from nfsn_api import makeNFSNHTTPRequest, output, fetchDNSRecordData, addDNSRecord, replaceDNSRecord
 
 IPAddress = NewType("IPAddress", Union[IPv4Address, IPv6Address])
-
-#load variables set in .env file
-load_dotenv()
 
 IPV4_PROVIDER_URL = os.getenv('IP_PROVIDER', "http://ipinfo.io/ip")
 IPV6_PROVIDER_URL = os.getenv('IPV6_PROVIDER', "http://v6.ipinfo.io/ip")
 
-NFSN_API_DOMAIN = "https://api.nearlyfreespeech.net"
-
-
-def randomRangeString(length:int) -> str:
-    character_options = string.ascii_uppercase + string.ascii_lowercase + string.digits
-    random_values = [random.choice(character_options) for _ in range(length)]
-    return ''.join(random_values)
-
-
 def doIPsMatch(ip1:IPAddress, ip2:IPAddress) -> bool:
     return ip1 == ip2
-
-
-def output(msg, type_msg=None, timestamp=None):
-    if timestamp is None:
-        timestamp = datetime.now().strftime("%y-%m-%d %H:%M:%S")
-    type_str = f"{type_msg}: " if type_msg is not None else ""
-    print(f"{timestamp}: {type_str}{msg}")
-
-
-def validateNFSNResponse(response):
-    if response is None:
-        print("none response received")
-        return
-    elif response == "":
-        print("empty string received")
-        return
-    elif response == []:
-        print("empty list received")
-        return
-
-    try:
-        response = response[0]
-    except Exception:
-        pass
-    if response.get("error") is not None:
-        output(response.get('error'), type_msg="ERROR")
-        output(response.get('debug'), type_msg="ERROR")
-
-
-def makeNFSNHTTPRequest(path, body, nfsn_username, nfsn_apikey):
-    url = NFSN_API_DOMAIN + path
-    headers = createNFSNAuthHeader(nfsn_username, nfsn_apikey, path, body)
-    headers["Content-Type"] = "application/x-www-form-urlencoded"
-
-    response = requests.post(url, data=body, headers=headers)
-    # response.raise_for_status()
-    if response.text != "":
-        data = response.json()
-    else:
-        data = ""
-    validateNFSNResponse(data)
-
-    return data
 
 def fetchCurrentIP(v6=False):
     response = requests.get(IPV4_PROVIDER_URL if not v6 else IPV6_PROVIDER_URL)
@@ -88,64 +28,27 @@ def digCurrentIP(v6=False):
     return os.popen(command_string).read().split()[0].replace('"', '')
 
 def fetchDomainIP(domain, subdomain, nfsn_username, nfsn_apikey, v6=False):
-    subdomain = subdomain or ""
-    path = f"/dns/{domain}/listRRs"
     record_type = "A" if not v6 else "AAAA"
-    body = {
-        "name": subdomain,
-        "type": record_type
-    }
-    body = urlencode(body)
+    data = fetchDNSRecordData(subdomain or "", domain, record_type, nfsn_username, nfsn_apikey)
 
-    response_data = makeNFSNHTTPRequest(path, body, nfsn_username, nfsn_apikey)
-
-    if len(response_data) == 0:
+    if data is None:
         output("No IP address is currently set.")
-        return
 
-    return response_data[0].get("data")
-
+    return data
 
 def replaceDomain(domain, subdomain, current_ip, nfsn_username, nfsn_apikey, create=False, ttl=3600, v6=False):
-
-    action = "replaceRR" if not create else "addRR"
-
-    path = f"/dns/{domain}/{action}"
     subdomain = subdomain or ""
     record_type = "A" if not v6 else "AAAA"
-    body = {
-        "name": subdomain,
-        "type": record_type,
-        "data": current_ip,
-        "ttl": ttl
-    }
-    body = urlencode(body)
 
     if subdomain == "":
         output(f"Setting {record_type} record on {domain} to {current_ip}...")
     else:
         output(f"Setting {record_type} record on {subdomain}.{domain} to {current_ip}...")
 
-    makeNFSNHTTPRequest(path, body, nfsn_username, nfsn_apikey)
-
-
-
-def createNFSNAuthHeader(nfsn_username, nfsn_apikey, url_path, body) -> Dict[str,str]:
-    # See https://members.nearlyfreespeech.net/wiki/API/Introduction for how this auth process works
-
-    salt = randomRangeString(16)
-    timestamp = int(datetime.now(timezone.utc).timestamp())
-    uts = f"{nfsn_username};{timestamp};{salt}"
-    # "If there is no request body, the SHA1 hash of the empty string must be used."
-    body = body or ""
-    body_hash = hashlib.sha1(bytes(body, 'utf-8')).hexdigest()
-
-    msg = f"{uts};{nfsn_apikey};{url_path};{body_hash}"
-
-    full_hash = hashlib.sha1(bytes(msg, 'utf-8')).hexdigest()
-
-    return {"X-NFSN-Authentication": f"{uts};{full_hash}"}
-
+    if create:
+        addDNSRecord(domain, subdomain, record_type, current_ip, ttl, nfsn_username, nfsn_apikey)
+    else:
+        replaceDNSRecord(domain, subdomain, record_type, current_ip, ttl, nfsn_username, nfsn_apikey)
 
 def getAllDNSRecords(domain, nfsn_username, nfsn_apikey):
     action = "listRRs"
@@ -162,10 +65,9 @@ def NFSNDnsToZoneFile(dnsRecords):
         host = record.get("name")
         return ("@" if host == "" else host) \
             + record.get("data")
-        
 
     dnsRecords = sorted(dnsRecords, key=sortKey )
-    
+
     outputList = []
     for record in dnsRecords:
         host = record.get("name")
@@ -206,11 +108,9 @@ def updateIPs(domain, subdomain, domain_ip, current_ip, nfsn_username, nfsn_apik
     else:
         output(f"They still don't match. Current IP: {current_ip} Domain IP: {domain_ip}")
 
-
 def ensure_present(value, name):
     if value is None:
         raise ValueError(f"Please ensure {name} is set to a value before running this script")
-
 
 def check_ips(nfsn_domain, nfsn_subdomain, nfsn_username, nfsn_apikey, v6=False, dig=False, create_if_not_exists=False):
 
@@ -219,13 +119,12 @@ def check_ips(nfsn_domain, nfsn_subdomain, nfsn_username, nfsn_apikey, v6=False,
         current_ip = digCurrentIP(v6=v6)
     else:
         current_ip = fetchCurrentIP(v6=v6)
-    
+
     if domain_ip is not None and doIPsMatch(ip_address(domain_ip), ip_address(current_ip)):
         output(f"IPs still match!  Current IP: {current_ip} Domain IP: {domain_ip}")
         return
 
     updateIPs(nfsn_domain, nfsn_subdomain, domain_ip, current_ip, nfsn_username, nfsn_apikey, v6=v6)
-
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='automate the updating of domain records to create Dynamic DNS for domains registered with NearlyFreeSpeech.net')
@@ -233,7 +132,7 @@ if __name__ == "__main__":
     parser.add_argument('--useDig', '-d', action='store_true', help='use the dig command to query dns')
     parser.add_argument('--export-to', help='the filename to export the zone file to')
     args = parser.parse_args()
-    
+
     nfsn_username = os.getenv('USERNAME')
     nfsn_apikey = os.getenv('API_KEY')
     nfsn_domain = os.getenv('DOMAIN')
@@ -255,5 +154,3 @@ if __name__ == "__main__":
         v6_enabled = os.getenv('ENABLE_IPV6', args.ipv6)
 
         check_ips(nfsn_domain, nfsn_subdomain, nfsn_username, nfsn_apikey, v6=v6_enabled, dig=use_dig_command, create_if_not_exists=False)
-    
-    

--- a/nfsn_api.py
+++ b/nfsn_api.py
@@ -1,0 +1,240 @@
+"""
+Shared NFSN API utilities for interacting with NearlyFreeSpeech.NET API.
+
+This module provides common functions for authentication, HTTP requests,
+and response validation when working with the NFSN RESTful API.
+"""
+
+import hashlib
+import random
+import requests
+import string
+from datetime import datetime, timezone
+from dotenv import load_dotenv
+from typing import Dict
+
+# Load environment variables from .env file
+load_dotenv()
+
+# NFSN API base domain
+NFSN_API_DOMAIN = "https://api.nearlyfreespeech.net"
+
+
+def randomRangeString(length: int) -> str:
+    """
+    Generate a random alphanumeric string of specified length.
+
+    Args:
+        length: Number of characters in the random string
+
+    Returns:
+        Random string containing uppercase, lowercase, and digit characters
+    """
+    character_options = string.ascii_uppercase + string.ascii_lowercase + string.digits
+    random_values = [random.choice(character_options) for _ in range(length)]
+    return ''.join(random_values)
+
+
+def output(msg, type_msg=None, timestamp=None):
+    """
+    Print a formatted log message with timestamp.
+
+    Args:
+        msg: The message to output
+        type_msg: Optional message type prefix (e.g., "ERROR")
+        timestamp: Optional timestamp string (defaults to current time)
+    """
+    if timestamp is None:
+        timestamp = datetime.now().strftime("%y-%m-%d %H:%M:%S")
+    type_str = f"{type_msg}: " if type_msg is not None else ""
+    print(f"{timestamp}: {type_str}{msg}")
+
+
+def validateNFSNResponse(response):
+    """
+    Validate and print errors from NFSN API responses.
+
+    Args:
+        response: The response data from NFSN API
+    """
+    if response is None:
+        print("none response received")
+        return
+    elif response == "":
+        print("empty string received")
+        return
+    elif response == []:
+        print("empty list received")
+        return
+
+    try:
+        response = response[0]
+    except Exception:
+        pass
+    if response.get("error") is not None:
+        output(response.get('error'), type_msg="ERROR")
+        output(response.get('debug'), type_msg="ERROR")
+
+
+def createNFSNAuthHeader(nfsn_username, nfsn_apikey, url_path, body) -> Dict[str, str]:
+    """
+    Create authentication header for NFSN API requests.
+
+    Implements the NFSN API authentication scheme as documented at:
+    https://members.nearlyfreespeech.net/wiki/API/Introduction
+
+    Args:
+        nfsn_username: NFSN account username
+        nfsn_apikey: NFSN API key
+        url_path: API endpoint path (e.g., "/dns/example.com/listRRs")
+        body: URL-encoded request body (or empty string/None)
+
+    Returns:
+        Dictionary containing X-NFSN-Authentication header
+    """
+    salt = randomRangeString(16)
+    timestamp = int(datetime.now(timezone.utc).timestamp())
+    uts = f"{nfsn_username};{timestamp};{salt}"
+    # "If there is no request body, the SHA1 hash of the empty string must be used."
+    body = body or ""
+    body_hash = hashlib.sha1(bytes(body, 'utf-8')).hexdigest()
+
+    msg = f"{uts};{nfsn_apikey};{url_path};{body_hash}"
+
+    full_hash = hashlib.sha1(bytes(msg, 'utf-8')).hexdigest()
+
+    return {"X-NFSN-Authentication": f"{uts};{full_hash}"}
+
+
+def makeNFSNHTTPRequest(path, body, nfsn_username, nfsn_apikey):
+    """
+    Make an authenticated POST request to the NFSN API.
+
+    Args:
+        path: API endpoint path (e.g., "/dns/example.com/addRR")
+        body: URL-encoded request body (or None)
+        nfsn_username: NFSN account username
+        nfsn_apikey: NFSN API key
+
+    Returns:
+        Parsed JSON response data, or empty string if no response body
+    """
+    url = NFSN_API_DOMAIN + path
+    headers = createNFSNAuthHeader(nfsn_username, nfsn_apikey, path, body)
+    headers["Content-Type"] = "application/x-www-form-urlencoded"
+
+    response = requests.post(url, data=body, headers=headers)
+    # response.raise_for_status()
+    if response.text != "":
+        data = response.json()
+    else:
+        data = ""
+    validateNFSNResponse(data)
+
+    return data
+
+
+def fetchDNSRecordData(name, domain, record_type, nfsn_username, nfsn_apikey):
+    """
+    Fetch DNS record data for a specific name and type.
+
+    Args:
+        name: Subdomain/record name (empty string for bare domain)
+        domain: The domain to query
+        record_type: DNS record type (e.g., "A", "AAAA", "TXT")
+        nfsn_username: NFSN account username
+        nfsn_apikey: NFSN API key
+
+    Returns:
+        The data field from the first matching DNS record, or None if not found
+    """
+    from urllib.parse import urlencode
+
+    path = f"/dns/{domain}/listRRs"
+    body = urlencode({
+        "name": name or "",
+        "type": record_type
+    })
+
+    response_data = makeNFSNHTTPRequest(path, body, nfsn_username, nfsn_apikey)
+
+    if len(response_data) == 0:
+        return None
+
+    return response_data[0].get("data")
+
+
+def addDNSRecord(domain, name, record_type, data, ttl, nfsn_username, nfsn_apikey):
+    """
+    Add a new DNS record.
+
+    Args:
+        domain: The domain to add the record to
+        name: Subdomain/record name (empty string for bare domain)
+        record_type: DNS record type (e.g., "A", "AAAA", "TXT")
+        data: The record data (e.g., IP address, TXT value)
+        ttl: Time to live in seconds
+        nfsn_username: NFSN account username
+        nfsn_apikey: NFSN API key
+    """
+    from urllib.parse import urlencode
+
+    path = f"/dns/{domain}/addRR"
+    body = urlencode({
+        "name": name or "",
+        "type": record_type,
+        "data": data,
+        "ttl": ttl
+    })
+
+    makeNFSNHTTPRequest(path, body, nfsn_username, nfsn_apikey)
+
+
+def replaceDNSRecord(domain, name, record_type, data, ttl, nfsn_username, nfsn_apikey):
+    """
+    Replace an existing DNS record.
+
+    Args:
+        domain: The domain containing the record
+        name: Subdomain/record name (empty string for bare domain)
+        record_type: DNS record type (e.g., "A", "AAAA", "TXT")
+        data: The new record data (e.g., IP address, TXT value)
+        ttl: Time to live in seconds
+        nfsn_username: NFSN account username
+        nfsn_apikey: NFSN API key
+    """
+    from urllib.parse import urlencode
+
+    path = f"/dns/{domain}/replaceRR"
+    body = urlencode({
+        "name": name or "",
+        "type": record_type,
+        "data": data,
+        "ttl": ttl
+    })
+
+    makeNFSNHTTPRequest(path, body, nfsn_username, nfsn_apikey)
+
+
+def removeDNSRecord(domain, name, record_type, data, nfsn_username, nfsn_apikey):
+    """
+    Remove a DNS record.
+
+    Args:
+        domain: The domain containing the record
+        name: Subdomain/record name (empty string for bare domain)
+        record_type: DNS record type (e.g., "A", "AAAA", "TXT")
+        data: The record data to remove (must match exactly)
+        nfsn_username: NFSN account username
+        nfsn_apikey: NFSN API key
+    """
+    from urllib.parse import urlencode
+
+    path = f"/dns/{domain}/removeRR"
+    body = urlencode({
+        "name": name or "",
+        "type": record_type,
+        "data": data
+    })
+
+    makeNFSNHTTPRequest(path, body, nfsn_username, nfsn_apikey)


### PR DESCRIPTION
Adds basic optional support for using Let's Encrypt to generate certificates using [domain-based ACME challenges](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge)